### PR TITLE
[14.0] account_statement_import_online: usability improvement on form view o…

### DIFF
--- a/account_statement_import_online/__manifest__.py
+++ b/account_statement_import_online/__manifest__.py
@@ -20,9 +20,9 @@
         "data/account_statement_import_online.xml",
         "security/ir.model.access.csv",
         "security/online_bank_statement_provider.xml",
+        "wizards/online_bank_statement_pull_wizard.xml",
         "views/account_journal.xml",
         "views/online_bank_statement_provider.xml",
-        "wizards/online_bank_statement_pull_wizard.xml",
     ],
     "installable": True,
 }

--- a/account_statement_import_online/models/account_journal.py
+++ b/account_statement_import_online/models/account_journal.py
@@ -76,17 +76,3 @@ class AccountJournal(models.Model):
         if "bank_statements_source" in vals or "online_bank_statement_provider" in vals:
             self._update_online_bank_statement_provider_id()
         return res
-
-    def action_online_bank_statements_pull_wizard(self):
-        provider_ids = self.mapped("online_bank_statement_provider_id").ids
-        return {
-            "name": _("Online Bank Statement Pull Wizard"),
-            "type": "ir.actions.act_window",
-            "res_model": "online.bank.statement.pull.wizard",
-            "views": [[False, "form"]],
-            "target": "new",
-            "context": {
-                "default_provider_ids": [(6, False, provider_ids)],
-                "active_test": False,
-            },
-        }

--- a/account_statement_import_online/security/online_bank_statement_provider.xml
+++ b/account_statement_import_online/security/online_bank_statement_provider.xml
@@ -8,7 +8,6 @@
     <record id="online_bank_statement_provider_multicompany" model="ir.rule">
         <field name="name">Online Bank Statement Provider multi-company</field>
         <field name="model_id" ref="model_online_bank_statement_provider" />
-        <field eval="True" name="global" />
         <field
             name="domain_force"
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>

--- a/account_statement_import_online/tests/online_bank_statement_provider_dummy.py
+++ b/account_statement_import_online/tests/online_bank_statement_provider_dummy.py
@@ -56,7 +56,7 @@ class OnlineBankStatementProviderDummy(models.Model):
                 transaction_date = fields.Datetime.to_string(transaction_date)
             lines.append(
                 {
-                    "name": "payment",
+                    "payment_ref": "payment",
                     "amount": amount,
                     "date": transaction_date,
                     "unique_import_id": str(

--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -383,10 +383,8 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
             order="date asc",
         )
         self.assertFalse(statements[0].balance_start)
-        self.assertFalse(statements[0].balance_end_real)
         self.assertTrue(statements[0].balance_end)
         self.assertTrue(statements[1].balance_start)
-        self.assertFalse(statements[1].balance_end_real)
 
     def test_wizard(self):
         journal = self.AccountJournal.create(
@@ -398,11 +396,8 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
                 "online_bank_statement_provider": "dummy",
             }
         )
-        action = journal.action_online_bank_statements_pull_wizard()
-        self.assertTrue(action["context"]["default_provider_ids"][0][2])
-
         wizard = self.OnlineBankStatementPullWizard.with_context(
-            action["context"]
+            active_model="account.journal", active_id=journal.id
         ).create(
             {"date_since": self.now - relativedelta(hours=1), "date_until": self.now}
         )

--- a/account_statement_import_online/views/account_journal.xml
+++ b/account_statement_import_online/views/account_journal.xml
@@ -47,17 +47,28 @@
                     />
                 </group>
             </page>
+            <xpath expr="/form/sheet" position="before">
+                    <header>
+                    <button
+                        type="action"
+                        name="%(online_bank_statement_pull_wizard_action)d"
+                        attrs="{'invisible': ['|', ('bank_statements_source', '!=', 'online'), ('online_bank_statement_provider', '=', False)]}"
+                        string="Pull Online Bank Statement"
+                    />
+                </header>
+            </xpath>
         </field>
     </record>
-    <record id="action_online_bank_statements_pull_wizard" model="ir.actions.server">
+    <record
+        id="action_online_bank_statements_pull_wizard"
+        model="ir.actions.act_window"
+    >
         <field name="name">Online Bank Statements Pull Wizard</field>
-        <field name="type">ir.actions.server</field>
-        <field name="model_id" ref="account.model_account_journal" />
+        <field name="res_model">online.bank.statement.pull.wizard</field>
+        <field name="target">new</field>
+        <field name="view_mode">form</field>
         <field name="binding_model_id" ref="account.model_account_journal" />
-        <field name="state">code</field>
-        <field name="code">
-            if records:
-                action = records.action_online_bank_statements_pull_wizard()
-        </field>
+        <field name="binding_view_types">list</field>
+        <field name="groups_id" eval="[(4, ref('account.group_account_user'))]" />
     </record>
 </odoo>

--- a/account_statement_import_online/views/online_bank_statement_provider.xml
+++ b/account_statement_import_online/views/online_bank_statement_provider.xml
@@ -10,11 +10,19 @@
         <field name="model">online.bank.statement.provider</field>
         <field name="arch" type="xml">
             <search string="Online Bank Statement Providers">
+                <field name="journal_id" />
                 <filter
                     name="active"
                     string="Inactive"
                     domain="[('active', '=', False)]"
                 />
+                <group name="groupby">
+                        <filter
+                        name="service_groupby"
+                        string="Service"
+                        context="{'group_by': 'service'}"
+                    />
+                </group>
             </search>
         </field>
     </record>
@@ -38,63 +46,41 @@
         <field name="arch" type="xml">
             <form string="Online Bank Statement Provider">
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button
-                            class="oe_stat_button"
-                            type="object"
-                            name="toggle_active"
-                            icon="fa-archive"
-                        >
+                        <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
+                        <group name="main" col="2">
+                        <group name="params">
+                            <field name="journal_id" />
+                            <field name="currency_id" />
+                            <field name="account_number" />
                             <field
-                                name="active"
-                                widget="boolean_button"
-                                options='{"terminology": "active"}'
+                                name="company_id"
+                                groups="base.group_multi_company"
                             />
-                        </button>
-                    </div>
-                    <notebook>
-                        <page name="details" string="Details">
-                            <group>
-                                <group groups="base.group_multi_company">
-                                    <field name="company_id" />
-                                </group>
-                                <group>
-                                    <field name="journal_id" />
-                                    <field name="currency_id" />
-                                    <field name="account_number" />
-                                </group>
-                                <group>
-                                    <field
-                                        name="service"
-                                        widget="dynamic_dropdown"
-                                        values="values_service"
-                                    />
-                                </group>
-                            </group>
-                        </page>
-                        <page name="pull" string="Scheduled Pull">
-                            <group>
-                                <group>
+                             <field
+                                name="service"
+                                widget="dynamic_dropdown"
+                                values="values_service"
+                            />
+                            <field name="active" invisible="1" />
+                         </group>
+                        <group name="pull" string="Scheduled Pull">
                                     <label for="interval_number" />
-                                    <div class="o_row">
+                                    <div class="o_row" id="interval_number">
                                         <field name="interval_number" class="ml8" />
                                         <field name="interval_type" />
                                     </div>
-                                </group>
-                                <group>
                                     <field name="next_run" />
-                                </group>
                             </group>
-                        </page>
-                        <page name="configuration" string="Configuration">
-                            <group>
-                                <group>
+                        <group name="configuration" string="Configuration">
                                     <field name="statement_creation_mode" />
                                     <field name="tz" />
-                                </group>
-                            </group>
-                        </page>
-                    </notebook>
+                    </group>
+                    </group>
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" widget="mail_followers" />
@@ -102,5 +88,19 @@
                 </div>
             </form>
         </field>
+</record>
+
+<record id="online_bank_statement_provider_action" model="ir.actions.act_window">
+    <field name="name">Online Bank Statement Providers</field>
+    <field name="res_model">online.bank.statement.provider</field>
+    <field name="view_mode">tree,form</field>
     </record>
+
+    <menuitem
+        id="online_bank_statement_provider_menu"
+        action="online_bank_statement_provider_action"
+        parent="account.account_banks_menu"
+        sequence="100"
+    />
+
 </odoo>

--- a/account_statement_import_online/wizards/online_bank_statement_pull_wizard.py
+++ b/account_statement_import_online/wizards/online_bank_statement_pull_wizard.py
@@ -2,7 +2,7 @@
 # Copyright 2019-2020 Dataplug (https://dataplug.io)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class OnlineBankStatementPullWizard(models.TransientModel):
@@ -10,12 +10,12 @@ class OnlineBankStatementPullWizard(models.TransientModel):
     _description = "Online Bank Statement Pull Wizard"
 
     date_since = fields.Datetime(
-        string="Since",
+        string="From",
         required=True,
         default=fields.Datetime.now,
     )
     date_until = fields.Datetime(
-        string="Until",
+        string="To",
         required=True,
         default=fields.Datetime.now,
     )
@@ -27,9 +27,34 @@ class OnlineBankStatementPullWizard(models.TransientModel):
         relation="online_bank_statement_provider_pull_wizard_rel",
     )
 
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if self.env.context.get("active_model") == "account.journal":
+            if self.env.context.get("active_ids"):
+                journals = self.env["account.journal"].browse(
+                    self.env.context["active_ids"]
+                )
+                res["provider_ids"] = journals.online_bank_statement_provider_id.ids
+            elif self.env.context.get("active_id"):
+                journal = self.env["account.journal"].browse(
+                    self.env.context["active_id"]
+                )
+                res["provider_ids"] = [journal.online_bank_statement_provider_id.id]
+        return res
+
     def action_pull(self):
         self.ensure_one()
         self.with_context(
             active_test=False,
         ).provider_ids._pull(self.date_since, self.date_until)
-        return {"type": "ir.actions.act_window_close"}
+        action = self.env.ref("account.action_bank_statement_tree").sudo().read([])[0]
+        if len(self.provider_ids) == 1:
+            action["context"] = {
+                "search_default_journal_id": self.provider_ids[0].journal_id.id
+            }
+        else:
+            action["domain"] = [
+                ("journal_id", "in", [o.journal_id.id for o in self.provider_ids])
+            ]
+        return action

--- a/account_statement_import_online/wizards/online_bank_statement_pull_wizard.xml
+++ b/account_statement_import_online/wizards/online_bank_statement_pull_wizard.xml
@@ -10,16 +10,10 @@
         <field name="model">online.bank.statement.pull.wizard</field>
         <field name="arch" type="xml">
             <form>
-                <field name="provider_ids" invisible="1" />
-                <group name="filter">
-                    <group name="date_range" colspan="2">
-                        <group>
-                            <field name="date_since" string="Since (at least)" />
-                        </group>
-                        <group>
-                            <field name="date_until" string="Until (at least)" />
-                        </group>
-                    </group>
+                <group name="main">
+                    <field name="provider_ids" widget="many2many_tags" required="1" />
+                            <field name="date_since" />
+                            <field name="date_until" />
                 </group>
                 <footer>
                     <button
@@ -27,11 +21,19 @@
                         string="Pull"
                         type="object"
                         default_focus="1"
-                        class="oe_highlight"
+                        class="btn-primary"
                     />
-                    <button string="Cancel" class="oe_link" special="cancel" />
+                    <button string="Cancel" special="cancel" />
                 </footer>
             </form>
         </field>
     </record>
+
+    <record id="online_bank_statement_pull_wizard_action" model="ir.actions.act_window">
+            <field name="name">Pull Online Bank Statement</field>
+            <field name="res_model">online.bank.statement.pull.wizard</field>
+            <field name="view_mode">form</field>
+                    <field name="target">new</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
…f online.bank.statement.provider: avoid speading the information on 3 tabs. As there are just a few fields, let's keep all the information directly visible.

Fix warning on search view of online.bank.statement.provider
Fix some tests
Button on journal form view to access the wizard
The wizard now returns the bank statements of the journal(s)
Fix wired strings